### PR TITLE
[TLKMSTR-000] chore(global): document setup and ghcr workflow

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -1,0 +1,62 @@
+name: Publish Docker Images
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docker/**'
+      - 'front/**'
+      - 'back/**'
+      - 'prod.docker-compose.yml'
+      - 'docker-compose.yml'
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    name: Build and push ${{ matrix.name }} image
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: front
+            context: .
+            dockerfile: docker/front.Dockerfile
+            image_suffix: front
+          - name: back
+            context: docker/php
+            dockerfile: prod.Dockerfile
+            image_suffix: back
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+
+      - name: Extract Docker metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}-${{ matrix.image_suffix }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: int128/kaniko-action@v1
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          cache: true
+          cache-repository: ghcr.io/${{ github.repository }}/cache/${{ matrix.image_suffix }}

--- a/README.md
+++ b/README.md
@@ -25,23 +25,27 @@
 - [Docker Compose](https://docs.docker.com/compose/)
 - [Make](https://www.gnu.org/software/make/)
 
-### Étapes
+### Démarrage rapide
 
-1. Cloner le dépôt :
+1. **Cloner le dépôt**
 
    ```bash
    git clone https://github.com/GoofyTeam/GoofyTalkmaster.git
    cd GoofyTalkmaster
    ```
 
-2. Lancer les conteneurs :
+2. **Préparer l'environnement Laravel**
 
    ```bash
-   docker-compose up -d
+   cp back/.env.example back/.env
+   docker compose up -d
+   make install
    make fresh
    ```
 
-3. Accéder à l'application :
+   > `make install` exécute `composer install` dans le conteneur `back-talkmaster` et `make fresh` lance les migrations et charge les données de démonstration.
+
+3. **Accéder aux services**
    - Frontend : [http://localhost:3000](http://localhost:3000)
    - Backend : [http://localhost:8000](http://localhost:8080)
    - En ligne : [https://talkmaster.stroyco.eu](https://talkmaster.stroyco.eu)


### PR DESCRIPTION
## Summary
- add a reusable GitHub Actions workflow that builds and pushes the front and back Docker images to GHCR on main updates
- document a quick start procedure in the README to help contributors launch the project locally

## Testing
- not run (documentation and CI configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68d5795e96d88327af892be88ba58dce