### PR TITLE
[TLKMSTR-000] Skip composer scripts during prod build

### DIFF
--- a/docker/php/prod.final.Dockerfile
+++ b/docker/php/prod.final.Dockerfile
@@ -41,7 +41,7 @@ COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 WORKDIR /app
 
 COPY back/composer.json back/composer.lock ./
-RUN composer install --no-interaction --no-progress --no-suggest --prefer-dist --no-dev --optimize-autoloader
+RUN composer install --no-interaction --no-progress --prefer-dist --no-dev --optimize-autoloader --no-scripts
 
 COPY back/package.json back/package-lock.json ./
 RUN npm ci --no-audit --no-fund --prefer-offline


### PR DESCRIPTION
## Summary
- prevent the production Docker build from executing Laravel's Composer scripts that rely on artisan
- add the --no-scripts flag to the Composer install step to avoid package discovery during the Kaniko build stage

## Testing
- not run (Dockerfile-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d58585554c8327a33c3910621355df