### PR TITLE
Fix permissions for Laravel production container

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -82,7 +82,10 @@ RUN --mount=type=cache,target=/var/cache/apk \
   /etc/supervisor/conf.d \
   /var/log/supervisor \
   /var/log/nginx \
-  /var/log/php-fpm
+  /var/log/php-fpm \
+  /var/lib/nginx \
+  /var/lib/nginx/tmp \
+  /var/lib/nginx/logs
 
 COPY --from=builder /usr/local/lib/php/extensions/ /usr/local/lib/php/extensions/
 COPY --from=builder /usr/local/etc/php/conf.d/ /usr/local/etc/php/conf.d/
@@ -100,7 +103,8 @@ RUN chmod +x /usr/local/bin/entrypoint.sh && \
   /var/log \
   /etc/supervisor/conf.d \
   $PHP_INI_DIR/conf.d \
-  /tmp
+  /tmp \
+  /var/lib/nginx
 
 # Configuration des permissions pour Laravel
 RUN mkdir -p $WORKDIR/storage/logs $WORKDIR/storage/framework/cache $WORKDIR/storage/framework/sessions $WORKDIR/storage/framework/views $WORKDIR/bootstrap/cache && \

--- a/docker/php/prod.final.Dockerfile
+++ b/docker/php/prod.final.Dockerfile
@@ -90,7 +90,10 @@ RUN --mount=type=cache,target=/var/cache/apk \
   /var/log/nginx \
   /var/log/php-fpm \
   /run/php \
-  && chown -R ${USER_NAME}:${GROUP_NAME} /var/log
+  /var/lib/nginx \
+  /var/lib/nginx/tmp \
+  /var/lib/nginx/logs \
+  && chown -R ${USER_NAME}:${GROUP_NAME} /var/log /var/lib/nginx
 
 COPY --from=extensions /usr/local/lib/php/extensions/ /usr/local/lib/php/extensions/
 COPY --from=extensions /usr/local/etc/php/conf.d/ /usr/local/etc/php/conf.d/
@@ -111,6 +114,7 @@ RUN chmod +x /usr/local/bin/prod.final.entrypoint.sh \
   /usr/local/bin/prod.final.entrypoint.sh \
   /var/log \
   /run/php \
+  /var/lib/nginx \
   && find $WORKDIR -type f -exec chmod 664 {} + \
   && find $WORKDIR -type d -exec chmod 775 {} +
 

--- a/docker/php/prod.final.entrypoint.sh
+++ b/docker/php/prod.final.entrypoint.sh
@@ -118,8 +118,43 @@ prepare_env_file() {
 setup_permissions() {
   info "Ensuring correct permissions on application directories..."
   mkdir -p "$WEB_ROOT/storage" "$WEB_ROOT/bootstrap/cache"
-  chown -R "$USER_NAME":"$USER_NAME" "$WEB_ROOT" /var/log/nginx /var/log/php-fpm /run/php
-  chmod -R 775 "$WEB_ROOT/storage" "$WEB_ROOT/bootstrap/cache"
+
+  local system_dirs=(
+    /var/log/nginx
+    /var/log/php-fpm
+    /run/php
+    /var/lib/nginx
+    /var/lib/nginx/tmp
+    /var/lib/nginx/logs
+    /var/lib/nginx/tmp/client_body
+    /var/lib/nginx/tmp/proxy
+    /var/lib/nginx/tmp/fastcgi
+    /var/lib/nginx/tmp/uwsgi
+    /var/lib/nginx/tmp/scgi
+  )
+
+  for dir in "${system_dirs[@]}"; do
+    if ! mkdir -p "$dir"; then
+      warning "Unable to create directory $dir (permissions issue?)."
+      continue
+    fi
+
+    if ! chown "$USER_NAME":"$USER_NAME" "$dir"; then
+      warning "Unable to change ownership of $dir."
+    fi
+
+    if ! chmod 775 "$dir"; then
+      warning "Unable to adjust permissions on $dir."
+    fi
+  done
+
+  if ! chown -R "$USER_NAME":"$USER_NAME" "$WEB_ROOT"; then
+    warning "Unable to change ownership of application files in $WEB_ROOT."
+  fi
+
+  if ! chmod -R 775 "$WEB_ROOT/storage" "$WEB_ROOT/bootstrap/cache"; then
+    warning "Unable to update permissions for Laravel writable directories."
+  fi
 }
 
 configure_supervisor() {


### PR DESCRIPTION
## Summary
- ensure the PHP container images create and own the /var/lib/nginx directories required for runtime
- harden the production entrypoint so it prepares nginx/php writable directories without aborting when running as a non-root user

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc1a1a82148327872ca67abc0e9a8d