### PR TITLE
[TLKMSTR-000] fix(front): fallback API base URL to origin

### DIFF
--- a/front/src/lib/utils.ts
+++ b/front/src/lib/utils.ts
@@ -5,7 +5,16 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-export const API_BASE_URL = import.meta.env.VITE_API_URL || "";
+const getDefaultApiBaseUrl = () => {
+  if (typeof window === "undefined") {
+    return "";
+  }
+
+  return window.location.origin;
+};
+
+export const API_BASE_URL =
+  import.meta.env.VITE_API_URL || getDefaultApiBaseUrl();
 
 export const SALLES = [
   "Salle A",


### PR DESCRIPTION
## Summary
- fall back to the current window origin when `VITE_API_URL` is not provided

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc511b8744832790cab86d8852c589